### PR TITLE
Andrew / Fixes UTC method deprecation

### DIFF
--- a/src/quest/historian.py
+++ b/src/quest/historian.py
@@ -4,7 +4,7 @@ import logging
 import traceback
 from asyncio import TaskGroup, Task
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import datetime, UTC
 from functools import wraps
 from typing import TypedDict, Any, Callable, Literal, Protocol, Reversible
 
@@ -207,7 +207,7 @@ def _prune(step_id: str, history: "History"):
 
 
 def _get_current_timestamp() -> str:
-    return datetime.utcnow().isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def _get_qualified_version(module_name, function_name, version_name: str) -> str:


### PR DESCRIPTION
I ran `main.py` on my laptop with Python 3.12, which completed successfully but gave me a deprecation warning about using `datetime.utcnow().isoformat()` due to its deprecation and future removal, and recommended switching over to `datetime.now(UTC).isoformat()`. I read the information on [this article](https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221/3) for some confirmation and context, and then tested the change. 

Nothing breaks as a result of this change, but the `isoformat()` produces a slightly different string on the new version (see console snippet below). If we're okay with that difference, then it should support compatibility with future versions of Python.

```
>>> datetime.utcnow().isoformat()
'2024-01-24T15:25:57.382516'
>>> datetime.now(UTC).isoformat()
'2024-01-24T15:26:03.174397+00:00'
```