### PR TITLE
0.2.0 - resource wrappers for workflow clients.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quest.py"
-version = "0.2.0-beta5"
+version = "0.2.0"
 description = "Framework for coordinated, long-running processes"
 authors = ["Gordon Bean <gbean@cs.byu.edu>"]
 packages = [{include = "quest", from = "src"}]

--- a/quest_test/test_external_actions.py
+++ b/quest_test/test_external_actions.py
@@ -101,7 +101,7 @@ async def test_external_queue():
 
     resources = await historian.get_resources(identity)
     assert 'items' in resources
-    assert resources['items']['type'] == 'asyncio.queues.Queue'
+    assert resources['items']['type'] == 'src.quest.external.Queue'
 
     await historian.record_external_event('items', identity, 'put', 7)
     await historian.record_external_event('items', identity, 'put', 8)

--- a/quest_test/test_manager.py
+++ b/quest_test/test_manager.py
@@ -190,7 +190,7 @@ async def test_get_queue():
         assert await result.get() is None
         await q.put(3)
         await q.put(4)
-        await asyncio.sleep(0.1)  # TODO - will stream_resources eliminate this need to sleep?
+        await asyncio.sleep(0.1)
         assert await result.get() == 7
         await finish.set()
 

--- a/src/quest/external.py
+++ b/src/quest/external.py
@@ -6,6 +6,41 @@ from typing import TypeVar, Generic
 from .historian import find_historian, SUSPENDED
 
 
+class Queue:
+    def __init__(self):
+        self._queue = asyncio.Queue()
+
+    async def put(self, item):
+        return await self._queue.put(item)
+
+    async def get(self):
+        return await self._queue.get()
+
+    async def empty(self):
+        return self._queue.empty()
+
+
+class Event:
+    # Why this class?
+    # When wrapped for historians, all methods become async
+    # So this class gives async versions of the methods
+    # so IDEs and typehints indicate the actual behavior
+    def __init__(self):
+        self._event = asyncio.Event()
+
+    async def wait(self):
+        await self._event.wait()
+
+    async def set(self):
+        self._event.set()
+
+    async def clear(self):
+        self._event.clear()
+
+    async def is_set(self):
+        return self._event.is_set()
+
+
 class State:
     def __init__(self, value):
         self._value = value
@@ -17,6 +52,7 @@ class State:
         self._value = value
 
     def value(self):
+        # TODO - why do we need this?
         return self._value
 
 
@@ -76,11 +112,11 @@ class ExternalResource(Generic[T]):
 
 
 def queue(name, identity):
-    return ExternalResource(name, identity, asyncio.Queue())
+    return ExternalResource(name, identity, Queue())
 
 
 def event(name, identity):
-    return ExternalResource(name, identity, asyncio.Event())
+    return ExternalResource(name, identity, Event())
 
 
 def state(name, identity, value):


### PR DESCRIPTION
See `test_manager.py` for an example of the client behavior this PR enables. 

Rather than have clients interact with the verbose, easy-to-botch signature of `record_external_event` or `send_event`, these wrappers give the client what looks like a regular resource (e.g. a `queue` or an `event`). Less to mess up. Cleaner-looking code. 