### PR TITLE
Bug Fix

### DIFF
--- a/src/quest/manager.py
+++ b/src/quest/manager.py
@@ -175,9 +175,9 @@ class WorkflowManager:
             )
 
         # Completed workflow
-        del self._workflows[workflow_id]
-        del self._workflow_tasks[workflow_id]
-        del self._workflow_data[workflow_id]
+        self._workflows.pop(workflow_id, None) # This will allow the code to fail more gracefully
+        self._workflow_tasks.pop(workflow_id, None)
+        self._workflow_data.pop(workflow_id, None)
 
     def start_workflow(self, workflow_type: str, workflow_id: str, *workflow_args, delete_on_finish: bool = True,
                        **workflow_kwargs):


### PR DESCRIPTION
## Error Report

During investigation I got this error
` KeyError: 'duck-1364046911727865909-1367875125134757908'
→ While trying to delete an entry from self._workflows:`

## Recommend action
quest.manager.py tries to clean up by deleting the workflow, and that’s where the KeyError hits because the ID is missing from the dict. My hunch is that when duck channel's id is added to the workflow manager it is not being properly added or stopped. 

```python
        if message['channel_id'] in self._duck_channels:
            workflow_id = f'duck-{message["channel_id"]}-{message["message_id"]}'
            self._workflow_manager.start_workflow(
                'duck',
                workflow_id,
                message["channel_id"],
                message
            )
```